### PR TITLE
fix layout bugs at different orientations

### DIFF
--- a/src/scss/layout/_banner.scss
+++ b/src/scss/layout/_banner.scss
@@ -5,7 +5,7 @@
   background: var(--overlay);
   display: grid;
   font-size: var(--small);
-  grid-gap: var(--gutter);
+  gap: var(--gutter);
   grid-template: 'bread links' auto / 1fr auto;
   padding: var(--half-shim) var(--gutter);
 }

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -2,7 +2,7 @@
   background: var(--callout);
   border-top: thick solid var(--border);
   display: grid;
-  grid-gap: var(--gutter);
+  gap: var(--gutter);
   grid-template-columns: repeat(auto-fit, minmax(var(--fit-min, 10rem), 1fr));
   font-size: var(--small);
   padding: var(--spacer) var(--gutter);

--- a/src/scss/layout/_slides.scss
+++ b/src/scss/layout/_slides.scss
@@ -34,13 +34,16 @@
 }
 
 [data-slides] {
-  display: grid;
   grid-area: banner / main / main;
-  grid-auto-rows: minmax(100vh, auto);
-  grid-template-columns: minmax(min-content, 1fr);
+
+  @media (orientation: landscape) {
+    display: grid;
+    grid-auto-rows: 100svh;
+  }
 
   [data-view='grid'] & {
-    grid-gap: var(--double-gutter);
+    display: grid;
+    gap: var(--double-gutter);
     grid-auto-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--min-page), 1fr));
     padding: var(--spacer) var(--gutter);
@@ -49,10 +52,15 @@
 }
 
 [id^='slide'] {
+  aspect-ratio: 16/9;
   container: slide / inline-size;
   display: grid;
   grid-template: 'slide' 1fr 'script' auto / 100%;
   scroll-snap-align: start;
+
+  @media (orientation: landscape) {
+    aspect-ratio: initial;
+  }
 
   [data-view='grid'] & {
     grid-template: 'slide' auto 'script' 1fr / 100%;

--- a/src/scss/patterns/_figures.scss
+++ b/src/scss/patterns/_figures.scss
@@ -40,7 +40,7 @@ img {
 
 [data-figure='content'] {
   display: grid;
-  grid-gap: var(--shim);
+  gap: var(--shim);
   grid-template-columns: [full-start] repeat(auto-fit, minmax(40%, 1fr)) [full-end];
 
   img,

--- a/src/scss/patterns/_media.scss
+++ b/src/scss/patterns/_media.scss
@@ -14,7 +14,7 @@
   --list-padding--default: 1em;
   align-items: var(--align, start);
   display: grid;
-  grid-gap: var(--media-gap, var(--gutter));
+  gap: var(--media-gap, var(--gutter));
   grid-template-areas: var(--reverse-y, 'image' 'content');
   margin: var(--newline) 0;
 


### PR DESCRIPTION
## Description

Slides looked very strange on mobile, with a portrait orientation. I tried to go through all the combined orientations and views, to make sure slides are adjusting to each situation. I also switched to `svh` for full-screen slides so they don't resize on scroll. 

## Related Issue(s)

- Reported here: https://hachyderm.io/@Di4na/114596319343133189

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

## Show me
Showing just the main slide view on a portrait mobile screen (the old fullscreen, and new multi-slide views):

![Screenshot 2025-05-30 at 3 14 17 PM](https://github.com/user-attachments/assets/e1dad2b6-6fd1-4a09-bd0f-b205d86d500d)
![Screenshot 2025-05-30 at 3 14 44 PM](https://github.com/user-attachments/assets/4282a140-885e-4084-bf85-b0ca884c36f0)
